### PR TITLE
fix: xcconfigを読み込みするように設定忘れてたので設定

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 		};
 		3557C7392A826A1300C72F17 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 35B289932C31BD120014AD63 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -328,6 +329,7 @@
 		};
 		3557C73A2A826A1300C72F17 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 35B289942C31BD120014AD63 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Debug.xcconfig
+++ b/Debug.xcconfig
@@ -7,4 +7,4 @@
 
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
-#include? "Signing.xcconfig"
+#include "Signing.xcconfig"

--- a/Release.xcconfig
+++ b/Release.xcconfig
@@ -7,4 +7,4 @@
 
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
-#include? "Signing.xcconfig"
+#include "Signing.xcconfig"


### PR DESCRIPTION
実機でビルドできないのは、xcconfigを読み込んでなかったからでした。
修正

あとSinging.xcconfigの内容３行でよかったです。
```
CODE_SIGN_STYLE = Automatic
DEVELOPMENT_TEAM =
CODE_SIGN_IDENTITY = Apple Development
```