### PR TITLE
カートが空の時に支払いボタンを無効化する

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/BottomBarFeature/OrderBottomBarView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/BottomBarFeature/OrderBottomBarView.swift
@@ -48,8 +48,8 @@ public struct OrderBottomBarView: View {
                     .foregroundColor(.white)
                     .padding(.leading, 50)
             }
-            .disabled(store.newOrder?.cart == nil || store.newOrder?.totalAmount == 0) // totalAmountだけだとViewのレンダリング時にdisableにならない問題があったのでcartの判定も追加した
-            .opacity(store.newOrder?.cart == nil || store.newOrder?.totalAmount == 0 ? 0.5 : 1)
+            .disabled(shouldDisableOrderButton())
+            .opacity(shouldDisableOrderButton() ? 0.5 : 1)
         }
         .padding(.horizontal, 40)
         .padding(.vertical, 15)
@@ -58,5 +58,9 @@ public struct OrderBottomBarView: View {
             store.send(.delegate(.removeOrders))
         }
         
+    }
+
+    func shouldDisableOrderButton() -> Bool {
+        return store.newOrder?.cart == nil || store.newOrder?.totalAmount == 0  // totalAmountだけだとViewのレンダリング時にdisableにならない問題があったのでcartの判定を追加した
     }
 }

--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/BottomBarFeature/OrderBottomBarView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/BottomBarFeature/OrderBottomBarView.swift
@@ -48,7 +48,8 @@ public struct OrderBottomBarView: View {
                     .foregroundColor(.white)
                     .padding(.leading, 50)
             }
-            
+            .disabled(store.newOrder?.cart == nil || store.newOrder?.totalAmount == 0) // totalAmountだけだとViewのレンダリング時にdisableにならない問題があったのでcartの判定も追加した
+            .opacity(store.newOrder?.cart == nil || store.newOrder?.totalAmount == 0 ? 0.5 : 1)
         }
         .padding(.horizontal, 40)
         .padding(.vertical, 15)


### PR DESCRIPTION
# タスクのURL
https://www.notion.so/cirkit/iOS-server-bf0d41d2b5194911bcb62d4edcf718a6?pvs=4

# 概要
- カートが空の時に支払い画面に遷移できないようにした
![image](https://github.com/user-attachments/assets/60489774-3c13-4f7a-810a-8d9a4e9dc65c)
![image](https://github.com/user-attachments/assets/f7887040-e203-4d65-8269-b6532667905e)


# 検証手順
- 画面レンダリング時にボタンがdisable状態になっている
- 商品をカートに追加し、商品をカートから削除したときにボタンがdisableになっている

# 未検証
- handyからOrderを呼び出した場合の挙動
  - 防ぐ処理を追加して、会計できなくなった時に困るので今回は実装を見送った