### PR TITLE
カートアイテムをスワイプして削除できるように

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderItemView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderItemView.swift
@@ -51,5 +51,12 @@ struct OrderItemView: View {
                     .fontWeight(.semibold)
             }
         }
+        .swipeActions {
+            Button(role: .destructive) {
+                onRemove()
+            } label: {
+                Label("削除", systemImage: "trash")
+            }
+        }
     }
 }


### PR DESCRIPTION
# タスクのURL

# 概要
- 注文リストのアイテムをスワイプして削除できるようにした
![image](https://github.com/user-attachments/assets/28df2188-c12f-4234-a499-2d11468351d7)


# 検証方法
- オーダーアイテムを追加
- スワイプして削除

# 確認して欲しいこと
- スワイプして削除したときに点数が0になること