### PR TITLE
レジ操作関連のナビゲーションをAppFeatureに移譲

### DIFF
--- a/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
+++ b/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
@@ -52,6 +52,10 @@ public struct AppFeature {
                     return .none
                 case .element(id: _, action: .paymentSuccess(.navigateToTapOrderEntry)):
                     return .send(.popToHome)
+                case .element(id: _, action: .cashDrawerClosing(.completeSettlement)):
+                    return .send(.popToHome)
+                case .element(id: _, action: .cashDrawerInspection(.completeInspection)):
+                    return .send(.popToHome)
                 default:
                     return .none
                 }

--- a/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
+++ b/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
@@ -50,11 +50,16 @@ public struct AppFeature {
                 case let .element(id: _, action: .payment(.navigateToSuccess(payment, orders, callNumber, totalQuantity, totalAmout))):
                     state.path.append(.paymentSuccess(PaymentSuccessFeature.State(payment: payment, orders: orders, callNumber: callNumber, totalQuantity: totalQuantity, totalAmount: totalAmout)))
                     return .none
+                // ホームに戻るケース
                 case .element(id: _, action: .paymentSuccess(.navigateToTapOrderEntry)):
                     return .send(.popToHome)
                 case .element(id: _, action: .cashDrawerClosing(.completeSettlement)):
                     return .send(.popToHome)
                 case .element(id: _, action: .cashDrawerInspection(.completeInspection)):
+                    return .send(.popToHome)
+                case .element(id: _, action: .cashDrawerSetup(.skipStartingCahierTransaction)):
+                    return .send(.popToHome)
+                case .element(id: _, action: .cashDrawerSetup(.startCashierTransaction)):
                     return .send(.popToHome)
                 default:
                     return .none

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
@@ -28,7 +28,7 @@ struct CashDrawerClosingView: View {
                             .padding(.bottom)
                         TitledAmountView(title: "誤差(B-A)", amount: store.cashDiscrepancy)
                         Spacer()
-                        TitleNavButton(title: "精算完了", bgColor: Color.cyan, fgColor: Color.white, destination: {HomeView()})
+                        TitleNavButton(title: "精算完了", bgColor: Color.cyan, fgColor: Color.white)
                             .simultaneousGesture(TapGesture().onEnded {
                                 store.send(.completeSettlement)
                             })

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
@@ -26,6 +26,7 @@ public struct CashDrawerOperationsFeature {
         case completeSettlement
         // レジ開け
         case startCashierTransaction
+        case skipStartingCahierTransaction
         // 点検
         case completeInspection
         
@@ -60,6 +61,9 @@ public struct CashDrawerOperationsFeature {
                 
             case .startCashierTransaction:
                 StartCacher().Execute(denominations: state.denominationFormListFeatureState.denominations)
+                return .none
+                
+            case .skipStartingCahierTransaction:
                 return .none
 
             case .completeInspection:

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
@@ -26,6 +26,8 @@ public struct CashDrawerOperationsFeature {
         case completeSettlement
         // レジ開け
         case startCashierTransaction
+        // 点検
+        case completeInspection
         
         case denominationFormListFeatureAction(DenominationFormListFeature.Action)
     }
@@ -58,6 +60,9 @@ public struct CashDrawerOperationsFeature {
                 
             case .startCashierTransaction:
                 StartCacher().Execute(denominations: state.denominationFormListFeatureState.denominations)
+                return .none
+
+            case .completeInspection:
                 return .none
                 
                 

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
@@ -17,8 +17,8 @@ struct CashDrawerSetupView: View {
                             .padding(.bottom)
                             .padding(.top, 50)
                         Spacer()
-                        TitleNavButton(title: "スキップ",bgColor: Color.secondary, fgColor: Color.white, destination: {HomeView()})
-                        TitleNavButton(title: "レジ開け完了", bgColor: Color.cyan, fgColor: Color.white, destination: {HomeView()})
+                        TitleNavButton(title: "スキップ",bgColor: Color.secondary, fgColor: Color.white)
+                        TitleNavButton(title: "レジ開け完了", bgColor: Color.cyan, fgColor: Color.white)
                             .simultaneousGesture(TapGesture().onEnded {
                                 store.send(.startCashierTransaction)
                             })

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
@@ -18,11 +18,14 @@ struct CashDrawerSetupView: View {
                             .padding(.top, 50)
                         Spacer()
                         TitleNavButton(title: "スキップ",bgColor: Color.secondary, fgColor: Color.white)
+                            .simultaneousGesture(TapGesture().onEnded {
+                                store.send(.skipStartingCahierTransaction)
+                            })
+
                         TitleNavButton(title: "レジ開け完了", bgColor: Color.cyan, fgColor: Color.white)
                             .simultaneousGesture(TapGesture().onEnded {
                                 store.send(.startCashierTransaction)
                             })
-                            .padding(.bottom)
                     }
                     .padding(.horizontal)
                     .frame(width: geometry.size.width * 0.3)

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
@@ -20,8 +20,10 @@ struct InspectionView: View {
                             .padding(.bottom)
                         TitledAmountView(title: "誤差(B-A)", amount: store.cashDiscrepancy)
                         Spacer()
-                        TitleNavButton(title: "点検完了", bgColor: Color.teal, fgColor: Color.white, destination: {HomeView()})
-                            .padding(.bottom)
+                        TitleNavButton(title: "点検完了", bgColor: Color.teal, fgColor: Color.white)
+                            .simultaneousGesture(TapGesture().onEnded {
+                                store.send(.completeInspection)
+                            })
                     }
                     .padding(.horizontal)
                     .frame(width: geometry.size.width * 0.3)

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/TitleNavButton.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/TitleNavButton.swift
@@ -3,21 +3,18 @@
 
 import SwiftUI
 
-struct TitleNavButton<Destination>: View where Destination : View {
+struct TitleNavButton: View {
     var title: String
     var bgColor: Color
     var fgColor: Color
-    var destination: () -> Destination
 
-    public init(title: String, bgColor: Color, fgColor: Color, destination: @escaping () -> Destination) {
+    public init(title: String, bgColor: Color, fgColor: Color) {
         self.title = title
         self.bgColor = bgColor
         self.fgColor = fgColor
-        self.destination = destination
     }
 
     var body: some View {
-        NavigationLink(destination: destination) {
             VStack(spacing: 0) {
                 Text(title)
                     .font(.largeTitle)
@@ -33,10 +30,9 @@ struct TitleNavButton<Destination>: View where Destination : View {
                     .fill(bgColor)
             }
             .padding(.bottom)
-        }
     }
 }
 
 #Preview {
-    TitleNavButton(title: "hoge", bgColor: Color.blue, fgColor: Color.white, destination: {HomeView()})
+    TitleNavButton(title: "hoge", bgColor: Color.blue, fgColor: Color.white)
 }


### PR DESCRIPTION
# タスクのURL
https://www.notion.so/cirkit/Navigation-order-item-pkey-54544a66e2ec4dfca08f1cbfbae91db8?pvs=4

# 概要
- レジ開け、レジ点検、レジ精算のナビゲーションをAppFeatureが行うように変更
- それに伴いHomeNavButtonをただのView化

https://github.com/user-attachments/assets/22af960e-5973-4651-88de-3f0e87d0b33c

# 検証方法
- レジ開け（別PRマージ後に確認）
- 点検
- 精算画面
- で処理を完了後、ホームに遷移したのちに他の画面に適切に遷移できる

# 未解決事項
- HomeNavButtonをButtonコンポーネントに変更して、action(state)を引数で渡せるようにする
  - この修正だけでorder-item-pkey問題が解決しなかったので、一旦そちらの修正を優先するため
