### PR TITLE
ホーム画面からレジ開け画面に遷移可能にする

### DIFF
--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
@@ -39,6 +39,7 @@ struct CashDrawerClosingView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .navigationTitle("精算")
     }
 }
 

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
@@ -32,6 +32,7 @@ struct CashDrawerSetupView: View {
             }
             
         }
+        .navigationTitle("レジ開け")
     }
 }
 

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
@@ -31,6 +31,7 @@ struct InspectionView: View {
             }
             
         }
+        .navigationTitle("点検")
     }
 }
 

--- a/LogoREGIUI/Sources/Features/HomeFeature/HomeView.swift
+++ b/LogoREGIUI/Sources/Features/HomeFeature/HomeView.swift
@@ -22,13 +22,23 @@ struct HomeView: View {
                     // 右列
                     VStack(alignment: .leading, spacing: 15) {
                         HomeNavigationButton(
+                            title: "レジ開け",
+                            subTitle: "",
+                            description: "レジ内の釣り銭を設定",
+                            fgColor: Color.primary,
+                            bgColor: Color(.secondarySystemFill),
+                            width: geometry.size.width * (1/3),
+                            height: geometry.size.height * (1/4),
+                            state: AppFeature.Path.State.cashDrawerSetup(CashDrawerOperationsFeature.State())
+                        )
+                        HomeNavigationButton(
                             title: "点検",
                             subTitle: "",
                             description: "レジ内の釣り銭を差分を確認",
                             fgColor: Color.primary,
                             bgColor: Color(.secondarySystemFill),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/3),
+                            height: geometry.size.height * (1/4),
                             state: AppFeature.Path.State.cashDrawerInspection(CashDrawerOperationsFeature.State())
                         )
                         HomeNavigationButton(
@@ -38,7 +48,7 @@ struct HomeView: View {
                             fgColor: Color.primary,
                             bgColor: Color(.secondarySystemFill),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/3),
+                            height: geometry.size.height * (1/4),
                             state: AppFeature.Path.State.cashDrawerClosing(CashDrawerOperationsFeature.State())
                         )
                         HomeNavigationButton(
@@ -48,7 +58,7 @@ struct HomeView: View {
                             fgColor: Color.primary,
                             bgColor: Color(.secondarySystemFill),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/3),
+                            height: geometry.size.height * (1/4),
                             state: AppFeature.Path.State.settings(SettingsFeature.State())
                         )
                     }


### PR DESCRIPTION
# タスクのURL
# 概要
- 遷移できなくなっていたレジ開け画面への遷移ボタンを追加しました
- それに伴う軽微なレイアウト修正
- 各画面のタイトルを追加
<img width="886" alt="image" src="https://github.com/user-attachments/assets/6ca3885d-4d19-495c-9179-8e0a8f214a35">

![image](https://github.com/user-attachments/assets/a85f0471-d0c8-4175-9315-124ae0db9211)

![image](https://github.com/user-attachments/assets/f91d4bba-0082-46af-bb25-0b9dc8b908b4)

![image](https://github.com/user-attachments/assets/86f1273e-ec2e-4b13-a3ba-08ce4f7ba771)


# 検証方法
- ホームからレジ開け画面に遷移できる

# 未修正事項
- ナビゲーション
  - 別PRで遷移ボタンのロジックを修正しているので、このPRでは修正しません