### PR TITLE
支払い完了画面の戻るボタンを非表示にする

### DIFF
--- a/LogoREGIUI/Sources/Features/PaymentSuccessFeature/PaymentSuccessView.swift
+++ b/LogoREGIUI/Sources/Features/PaymentSuccessFeature/PaymentSuccessView.swift
@@ -147,6 +147,7 @@ struct PaymentSuccessView: View {
         }
         .navigationTitle("お支払い完了")
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }


### PR DESCRIPTION
# 概要
- 支払い完了画面の戻るボタンを非表示にする
![image](https://github.com/user-attachments/assets/9b339a20-4d41-4324-ae6c-659fc434e980)

# 見送り事項
- 遷移履歴をremoveして、完全に戻れなくすること
  - 釣り銭修正機能の実装余地を残すため