### PR TITLE
カートが空の時に注文入力画面の状態を初期化する

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderEntryFeature.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderEntryFeature.swift
@@ -56,6 +56,10 @@ public struct OrderEntryFeature {
         Reduce<State, Action> { state, action in
             switch action {
             case .onAppear:
+                // ホームから遷移するときに初期化したいが、dismissで戻る時は初期化したくないので、cartItemが空のときのみ初期化
+                if state.order.cart.items.isEmpty {
+                    state.order = Order()
+                }
                 return .none
                 
             case .fetchAllData:


### PR DESCRIPTION
# タスクのURL
https://www.notion.so/cirkit/Navigation-order-item-pkey-54544a66e2ec4dfca08f1cbfbae91db8?pvs=4

# 概要
- 注文画面が初期化されず、同じOrderIDの注文が飛んでしまう問題を解決
- ホームから遷移するときに初期化したいが、dismissで戻る時は初期化したくないので、cartItemが空のときのみ初期化する

https://github.com/user-attachments/assets/ae45058f-54ce-42b7-8fad-b0b5b3fad956


# 検証方法
- 1度注文する
- もう一度同じ商品を注文する

# 未解決事項
- HomeNavButtonをタップした時に`state.path.append`して、別のStack扱いで遷移して解決するのが最善だろうが、遷移のロジックを修正する必要が出てくる（button actionを渡せるようにするなど）
- 2種類の遷移ロジックを共存させると、今後同様のライフサイクル問題が発生する可能性がある
- やっつけ仕事で負債を残すくらいならOrderEntryだけの修正負債だけで済ませたほうがいいのでは
- HomeNavButtonはいずれ改修したい