### PR TITLE
決済完了画面から注文入力画面に戻れるようにする

### DIFF
--- a/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
+++ b/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
@@ -50,9 +50,14 @@ public struct AppFeature {
                 case let .element(id: _, action: .payment(.navigateToSuccess(payment, orders, callNumber, totalQuantity, totalAmout))):
                     state.path.append(.paymentSuccess(PaymentSuccessFeature.State(payment: payment, orders: orders, callNumber: callNumber, totalQuantity: totalQuantity, totalAmount: totalAmout)))
                     return .none
-                // ホームに戻るケース
+
+                // 決済完了後に注文入力画面に戻る
                 case .element(id: _, action: .paymentSuccess(.navigateToTapOrderEntry)):
-                    return .send(.popToHome)
+                    state.path.removeAll() // 前の注文の決済完了画面への遷移を防ぐため
+                    state.path.append(.orderEntry(OrderEntryFeature.State()))
+                    return .none
+
+                // ホームに戻るケース
                 case .element(id: _, action: .cashDrawerClosing(.completeSettlement)):
                     return .send(.popToHome)
                 case .element(id: _, action: .cashDrawerInspection(.completeInspection)):


### PR DESCRIPTION
# タスクのURL
https://www.notion.so/cirkit/Navigation-order-item-pkey-54544a66e2ec4dfca08f1cbfbae91db8?pvs=4

## 前提
#63 がMergeされていること

# 概要
- 決済完了画面から注文画面に遷移できるようにする
- 遷移先から前の決済完了画面に戻れないようにした

https://github.com/user-attachments/assets/bf72d156-532e-451a-ade5-94f7cd48b5f3

# 検証方法
- 決済完了後、注文画面に遷移

# 未解決事項
- #63 Merge前に下記の図の通り遷移すると、同じOrderIdが発行されるのでpkey重複でオーダーできません
![image](https://github.com/user-attachments/assets/d14c0912-7826-463c-a445-669f08412e33)
