### PR TITLE
伝票呼び出しシートから伝票を選択しやすくする

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/ChooseOrderSheetFeature/ChooseOrderSheetView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/ChooseOrderSheetFeature/ChooseOrderSheetView.swift
@@ -47,36 +47,37 @@ public struct ChooseOrderSheetView: View {
                     }
                     .pickerStyle(SegmentedPickerStyle())
                 }
-                .frame(maxHeight: 300)
+                .frame(maxHeight: 200)
                 .padding(20)
                 
                 Spacer()
                 
-                ForEach(store.seats, id: \.id) { seat in
-                    if seat.name.hasPrefix(getGroupName()) {
-                        Button(action: {
-                            Task {
-                                store.send(.delegate(.getUnpaidOrdersById(seat.id)))
-                                dismiss()
-                            }
-                        }, label: {
-                            VStack(spacing: 0) {
-                                Text("\(seat.name)")
-                                    .font(.largeTitle)
-                                    .fontWeight(.semibold)
-                                    .lineLimit(0)
-                            }
-                            .foregroundColor(Color.white)
-                            .frame(maxWidth: .infinity, minHeight: 25, alignment: .center)
-                            .clipped()
-                            .padding(.vertical, 8)
-                            .background {
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                    .fill(Color.green)
-                            }
-                            .padding(8)
-                        })
-                    }
+                ScrollView {
+                    ForEach(store.seats, id: \.id) { seat in
+                        if seat.name.hasPrefix(getGroupName()) {
+                            Button(action: {
+                                Task {
+                                    store.send(.delegate(.getUnpaidOrdersById(seat.id)))
+                                    dismiss()
+                                }
+                            }, label: {
+                                VStack(spacing: 0) {
+                                    Text("\(seat.name)")
+                                        .font(.largeTitle)
+                                        .fontWeight(.semibold)
+                                        .lineLimit(0)
+                                }
+                                .foregroundColor(Color.white)
+                                .frame(maxWidth: .infinity, minHeight: 25, alignment: .center)
+                                .clipped()
+                                .padding(.vertical, 8)
+                                .background {
+                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                        .fill(Color.green)
+                                }
+                                .padding(8)
+                            })
+                        }}
                 }
             }
             .background(Color(.secondarySystemBackground))
@@ -98,3 +99,12 @@ public struct ChooseOrderSheetView: View {
         }
     }
 }
+
+// Picker要素のPaddingを調整するextension
+extension UISegmentedControl {
+    override open func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        self.setContentHuggingPriority(.defaultLow, for: .vertical)
+    }
+}
+


### PR DESCRIPTION
# PBIのURL

# 概要
- Pickerのサイズを押しやすいサイズに変更
- 伝票一覧をスクロールできるように変更
  - 伝票呼び出し画面で、席数がめっちゃ増えた場合表示されない問題を解決

https://github.com/user-attachments/assets/fc226ea7-dbba-4cd6-9222-5622ba4893f5

# 検証方法
- 座席を大量に設定
- 伝票一覧をスクロール

# 未解決事項
- 特になし
- 既存の仕様を踏襲