### PR TITLE
点検・精算画面レンダリング時にあるべき釣り銭を読み込むメソッドを追加する

### DIFF
--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
@@ -39,6 +39,9 @@ struct CashDrawerClosingView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .onAppear{
+            store.send(.calculateExpectedCashAmount)
+        }
         .navigationTitle("精算")
     }
 }

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/InspectionView.swift
@@ -33,6 +33,9 @@ struct InspectionView: View {
             }
             
         }
+        .onAppear{
+            store.send(.calculateExpectedCashAmount)
+        }
         .navigationTitle("点検")
     }
 }


### PR DESCRIPTION
# PBIのURL
https://www.notion.so/cirkit/87cb7981f3ed4f4e918d643e6d2a175a?pvs=4


# 概要
- 点検画面と精算画面に適切にあるべき釣り銭が読み込まれるようにした

https://github.com/user-attachments/assets/c25587f1-48eb-4142-a325-c4b98464c755

# 検証方法
- レジ開け
- 点検
- 精算
- の手順を実施した時に、あるべき釣り銭が正常に変動する

# 未解決事項
- いつレジ開けしたかわからない
  - すでに釣り銭があるにも関わらず、0と表示される
  - 余裕があれば、釣り銭のTextFieldに反映させたい
- 精算後、なんのアクションもないので精算できたかわからない
  - アラートを出したい
  - 履歴を表示する機能をつけたい
- そもそも論
  - レジ開け後はレジ開けできないようにする
  - レジ開け後でないと精算・点検できないようにする
  - 対応をしたい
