### PR TITLE
ドリップ手法がひとつのコーヒーの金額を表示する

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/ProductStackFeature/ProductStackView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/ProductStackFeature/ProductStackView.swift
@@ -16,7 +16,11 @@ public struct ProductStackView: View {
                     .fontWeight(.regular)
             }
         } else {
-            EmptyView()
+            Text("¥\(product.coffeeHowToBrews?.first?.amount ?? 0)") // warning回避のため、金額未記載の場合は0を返す
+                .font(.title2)
+                .fontWeight(.regular)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(1)
         }
     }
 


### PR DESCRIPTION
# タスクのURL

# 概要
- ドリップ手法がひとつのコーヒーの金額が表示されない問題を修正
![image](https://github.com/user-attachments/assets/fc993499-0a3a-4383-bc3a-9ce68320e2a1)


# 検証手法
- ドリップ手法がひとつのコーヒーを選択し、正しく金額が表示、反映されるか確認

# 未解決事項
- 特になし