### PR TITLE
レジ開け時完了ボタンにアラートを追加して入力額を確認させる

### DIFF
--- a/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
+++ b/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
@@ -66,7 +66,7 @@ public struct AppFeature {
                     return .send(.popToHome)
                 case .element(id: _, action: .cashDrawerSetup(.skipStartingCahierTransaction)):
                     return .send(.popToHome)
-                case .element(id: _, action: .cashDrawerSetup(.startCashierTransaction)):
+                case .element(id: _, action: .cashDrawerSetup(.alert(.presented(.okTapped)))):
                     return .send(.popToHome)
                 default:
                     return .none

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerSetupView.swift
@@ -36,6 +36,7 @@ struct CashDrawerSetupView: View {
             
         }
         .navigationTitle("レジ開け")
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }
 


### PR DESCRIPTION
# 概要
タイトルの通り

- okTappedで画面遷移します
- cancelでalertを破棄します

# 申し送り
- iflet使ってalertの状態を追跡できるようにしときました
- これでSwiftUIから紫びっくりを突きつけられません

https://github.com/user-attachments/assets/0a8c766b-a8ff-46f2-b784-ce951997f7a0

