### PR TITLE
精算完了時にアラートを表示して、自動でスクショを撮影する

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -306,6 +306,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LogoREGI;
+				INFOPLIST_KEY_NSBluetoothPeripheralUsageDescription = "Use Bluetooth for communication with the printer.";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Use Local Network for communication with the printer or discovery the printers.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Use screenshot for casher closing";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
@@ -339,6 +342,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LogoREGI;
+				INFOPLIST_KEY_NSBluetoothPeripheralUsageDescription = "Use Bluetooth for communication with the printer.";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Use Local Network for communication with the printer or discovery the printers.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Use screenshot for casher closing";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Use Bluetooth for communication with the printer.</string>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Use Local Network for communication with the printer or discovery the printers.</string>
-	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>Use Bluetooth for communication with the printer.</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
+++ b/LogoREGIUI/Sources/Features/AppFeature/AppFeature.swift
@@ -60,7 +60,7 @@ public struct AppFeature {
                     return .none
 
                 // ホームに戻るケース
-                case .element(id: _, action: .cashDrawerClosing(.completeSettlement)):
+                case .element(id: _, action: .cashDrawerClosing(.alert(.presented(.settlementOkTapped)))):
                     return .send(.popToHome)
                 case .element(id: _, action: .cashDrawerInspection(.completeInspection)):
                     return .send(.popToHome)

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
@@ -49,6 +49,7 @@ struct CashDrawerClosingView: View {
             store.send(.calculateExpectedCashAmount)
         }
         .navigationTitle("精算")
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }
 

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerClosingView.swift
@@ -30,6 +30,12 @@ struct CashDrawerClosingView: View {
                         Spacer()
                         TitleNavButton(title: "精算完了", bgColor: Color.cyan, fgColor: Color.white)
                             .simultaneousGesture(TapGesture().onEnded {
+                                // 描画しているUIViewを取得して渡す
+                                if let windowScene = UIApplication.shared.connectedScenes
+                                    .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+                                   let rootView = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController?.view {
+                                    store.send(.takeScreenshot(rootView))
+                                }
                                 store.send(.completeSettlement)
                             })
                     }

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
@@ -3,6 +3,7 @@
 import Foundation
 import ComposableArchitecture
 import LogoREGICore
+import UIKit
 
 @Reducer
 public struct CashDrawerOperationsFeature {
@@ -31,6 +32,7 @@ public struct CashDrawerOperationsFeature {
         case completeInspection
         
         case denominationFormListFeatureAction(DenominationFormListFeature.Action)
+        case takeScreenshot(UIView)
     }
     
     public var body: some Reducer<State, Action> {
@@ -72,8 +74,20 @@ public struct CashDrawerOperationsFeature {
                 
             case .denominationFormListFeatureAction:
                 return .send(.calculateCashDrawerTotal)
+            case let .takeScreenshot(view):
+                takeScreenshot(from: view)
+                return .none
             }
             
         }
+    }
+    // スクリーンショットを撮る
+    private func takeScreenshot(from view: UIView) {
+        let renderer = UIGraphicsImageRenderer(size: view.bounds.size)
+        let image = renderer.image { ctx in
+            view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
+        }
+        // アルバムに保存
+        UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
     }
 }

--- a/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
+++ b/LogoREGIUI/Sources/Features/CashDrawerOperationsFeature/CashDrawerOperationsFeature.swift
@@ -41,6 +41,7 @@ public struct CashDrawerOperationsFeature {
         @CasePathable
         public enum Alert {
             case okTapped
+            case settlementOkTapped
             case cancel
         }
     }
@@ -67,8 +68,20 @@ public struct CashDrawerOperationsFeature {
                 state.cashDiscrepancy = state.cashDrawerTotal - state.expectedCashAmount
                 return .none
                 
+            // レジ締め
             case .completeSettlement:
-                Settle().Execute(denominations: state.denominationFormListFeatureState.denominations)
+                state.alert = AlertState {
+                    TextState("精算確認")
+                } actions: {
+                    ButtonState(action: .settlementOkTapped) {
+                        TextState("OK")
+                    }
+                    ButtonState(action: .cancel) {
+                        TextState("キャンセル")
+                    }
+                } message: {
+                    TextState("現在の入力額で精算処理を行い、スクリーンショットを記録します。本当によろしいですか？")
+                }
                 return .none
                 
             case .alert:
@@ -79,6 +92,8 @@ public struct CashDrawerOperationsFeature {
                 case .okTapped:
                     // 画面遷移する
                     StartCacher().Execute(denominations: state.denominationFormListFeatureState.denominations)
+                case .settlementOkTapped:
+                    Settle().Execute(denominations: state.denominationFormListFeatureState.denominations)
                 case .cancel:
                     // アラートを閉じる
                     state.alert = nil


### PR DESCRIPTION
# 概要
表題の通り

# 未解決事項
- takeScreenshotのロジックはここに書かない方がいい気がするので、後に別レイヤー・ファイルに移動するかも？
- 精算ボタン押した瞬間にスクショを撮っているので、今回は一旦これでいくけど、後でちゃんと条件分岐設定する


https://github.com/user-attachments/assets/56c78242-eb3d-4c6e-a3c8-498666f66b23

