### PR TITLE
未会計伝票にオーダーがない場合は支払い画面に遷移させない

### DIFF
--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderEntryView.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/OrderEntryView.swift
@@ -55,6 +55,7 @@ struct OrderEntryView: View {
             }
         }
         .navigationTitle("注文入力")
+        .alert($store.scope(state: \.alert, action: \.alert))
     }
 }
 


### PR DESCRIPTION
# タスクのURL

https://www.notion.so/cirkit/LR-orders-nil-append-296bb781b1ff44d2a73fc8c81a69471b?pvs=4

# 概要
- 未会計伝票にオーダーがなかった場合は、アラートを表示して支払い画面に遷移させない
- オーダーがある場合、支払い画面に遷移させる

# 検証手法
- Adminから座席を追加
- その状態で会計
- アラートが表示されて、会計できないことを確認
- Handyからオーダー
- 通常通り会計できることを確認

https://github.com/user-attachments/assets/e73aa3a5-882e-4949-9cf8-4ea38c72a778




# 未解決事項
- 特になし