### PR TITLE
支払いボタンを連打できないようにする

### DIFF
--- a/LogoREGIUI/Sources/Features/PaymentFeature/BottomBarView.swift
+++ b/LogoREGIUI/Sources/Features/PaymentFeature/BottomBarView.swift
@@ -4,12 +4,14 @@ import LogoREGICore
 struct BottomBarView: View {
     let totalQuantity: UInt32
     let payment: Payment
+    let isPayButtonEnabled: Bool
     
     let onTapPay: () -> Void
     
-    public init(totalQuantity: UInt32, payment: Payment, onTapPay: @escaping () -> Void) {
+    public init(totalQuantity: UInt32, payment: Payment,isPayButtonEnabled: Bool, onTapPay: @escaping () -> Void) {
         self.totalQuantity = totalQuantity
         self.payment = payment
+        self.isPayButtonEnabled = isPayButtonEnabled
         self.onTapPay = onTapPay
     }
     
@@ -51,7 +53,8 @@ struct BottomBarView: View {
                     .foregroundColor(.white)
                     .padding(.leading, 70)
             }
-            .disabled(!payment.isEnoughAmount())
+            .disabled(!payment.isEnoughAmount() || !isPayButtonEnabled)
+            .opacity(!isPayButtonEnabled ? 0.5 : 1)
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 40)
@@ -67,7 +70,7 @@ struct BottomBarView: View {
 }
 
 #Preview {
-    BottomBarView(totalQuantity: 10, payment: Payment(type: PaymentType.cash, orderIds: [], paymentAmount: 1000, receiveAmount: 100), onTapPay: {
+    BottomBarView(totalQuantity: 10, payment: Payment(type: PaymentType.cash, orderIds: [], paymentAmount: 1000, receiveAmount: 100), isPayButtonEnabled: true, onTapPay: {
         print("tap")
     })
 }

--- a/LogoREGIUI/Sources/Features/PaymentFeature/PaymentFeature.swift
+++ b/LogoREGIUI/Sources/Features/PaymentFeature/PaymentFeature.swift
@@ -16,6 +16,8 @@ public struct PaymentFeature {
         
         @Presents var alert: AlertState<Action.Alert>?
         
+        var isPayButtonEnabled: Bool = true
+        
         /**
          * 新しい注文がある場合
          */
@@ -62,12 +64,14 @@ public struct PaymentFeature {
             case .numericKeyboardAction:
                 return .none
             case .onTapPay:
+                state.isPayButtonEnabled = false
                 return .run { [newOrder = state.newOrder, payment = state.payment] send in
                     await send(.onDidPayment(Result {
                         await NewPayment().Execute(payment: payment, postOrder: newOrder)
                     }))
                 }
             case let .onDidPayment(.success(result)):
+                state.isPayButtonEnabled = true
                 if result.error != nil {
                     state.alert = AlertState {
                         TextState("サーバーとの通信に失敗しました")

--- a/LogoREGIUI/Sources/Features/PaymentFeature/PaymentView.swift
+++ b/LogoREGIUI/Sources/Features/PaymentFeature/PaymentView.swift
@@ -59,6 +59,7 @@ struct PaymentView: View {
                     BottomBarView(
                         totalQuantity: store.totalQuantity,
                         payment: store.payment,
+                        isPayButtonEnabled: store.isPayButtonEnabled,
                         onTapPay: {
                             store.send(.onTapPay)
                         }


### PR DESCRIPTION
# PBI
https://www.notion.so/cirkit/LR-PaymentView-6eb10cc666e04135b3deacece13756c6?pvs=4

# 概要
- 支払い画面の支払うボタンを連打できないようにした

## 申し送り
-ボタンが押せない間、ボタンの色をopacityに50%設定しています
- その判定条件をdisable判定の物と揃えていますが、true/falseを逆にした方がよかったら指摘してください