### PR TITLE
[商品モック] ProductQueryMockを注文入力画面に流し込めるようにする

### DIFF
--- a/LogoREGICore/Sources/DI.swift
+++ b/LogoREGICore/Sources/DI.swift
@@ -43,7 +43,10 @@ private enum GrpcClientKey: DependencyKey {
 
 
 private enum ServerProductQueryServiceKey: DependencyKey {
-    static let liveValue: any ProductQueryService = ProductQueryServiceServer()
+    static var liveValue: any ProductQueryService {
+        let config = DependencyValues().configRepository.load()
+        return config.isUseProductMock ? ProductQueryServiceMock() : ProductQueryServiceServer()
+    }
 }
 private enum ServerDiscountRepositoryKey: DependencyKey {
     static let liveValue: any DiscountRepository = DiscountRepositoryServer()

--- a/LogoREGICore/Sources/DI.swift
+++ b/LogoREGICore/Sources/DI.swift
@@ -43,10 +43,7 @@ private enum GrpcClientKey: DependencyKey {
 
 
 private enum ServerProductQueryServiceKey: DependencyKey {
-    static var liveValue: any ProductQueryService {
-        let config = DependencyValues().configRepository.load()
-        return config.isUseProductMock ? ProductQueryServiceMock() : ProductQueryServiceServer()
-    }
+    static let liveValue: any ProductQueryService = ProductQueryServiceServer()
 }
 private enum ServerDiscountRepositoryKey: DependencyKey {
     static let liveValue: any DiscountRepository = DiscountRepositoryServer()

--- a/LogoREGICore/Sources/Domain/Config.swift
+++ b/LogoREGICore/Sources/Domain/Config.swift
@@ -21,6 +21,8 @@ public struct Config: Equatable {
     public var squareAccessToken: String
     public var squareTerminalDeviceId: String
     
+    public var isUseProductMock: Bool
+    
     public init() {
         self.clientId = ULID().ulidString
         self.clientName = ""
@@ -31,9 +33,10 @@ public struct Config: Equatable {
         self.isUseSquareTerminal = false
         self.squareAccessToken = ""
         self.squareTerminalDeviceId = ""
+        self.isUseProductMock = false
     }
     
-    public init(clientId: String, clientName: String, isTrainingMode: Bool, isUsePrinter: Bool, isPrintKitchenReceipt: Bool, isUseSquareTerminal: Bool, squareAccessToken: String, squareTerminalDeviceId: String, hostUrl: String) {
+    public init(clientId: String, clientName: String, isTrainingMode: Bool, isUsePrinter: Bool, isPrintKitchenReceipt: Bool, isUseSquareTerminal: Bool, squareAccessToken: String, squareTerminalDeviceId: String, hostUrl: String, isUseProductMock: Bool = false) {
         self.clientId = clientId
         self.clientName = clientName
         self.isTrainingMode = isTrainingMode
@@ -43,6 +46,7 @@ public struct Config: Equatable {
         self.isUseSquareTerminal = isUseSquareTerminal
         self.squareAccessToken = squareAccessToken
         self.squareTerminalDeviceId = squareTerminalDeviceId
+        self.isUseProductMock = isUseProductMock
     }
 }
 

--- a/LogoREGICore/Sources/Infra/AppStorage/ConfigAppStorage.swift
+++ b/LogoREGICore/Sources/Infra/AppStorage/ConfigAppStorage.swift
@@ -20,12 +20,14 @@ public struct ConfigAppStorage: ConfigRepository {
     @AppStorage("squareAccessToken") var squareAccessToken = ""
     @AppStorage("squareTerminalDeviceId") var squareTerminalDeviceId = ""
     
+    @AppStorage("isUseProductMock") var isUseProductMock = false
+    
     func load() -> Config {
         if(self.clientId.isEmpty) {
             save(config: Config())
         }
         
-        return Config(clientId: self.clientId, clientName: self.clientName, isTrainingMode: self.isTrainingMode, isUsePrinter: self.isUsePrinter, isPrintKitchenReceipt: self.isPrintKitchenReceipt, isUseSquareTerminal: self.isUseSquareTerminal, squareAccessToken: self.squareAccessToken, squareTerminalDeviceId: self.squareTerminalDeviceId,hostUrl: self.hostUrl)
+        return Config(clientId: self.clientId, clientName: self.clientName, isTrainingMode: self.isTrainingMode, isUsePrinter: self.isUsePrinter, isPrintKitchenReceipt: self.isPrintKitchenReceipt, isUseSquareTerminal: self.isUseSquareTerminal, squareAccessToken: self.squareAccessToken, squareTerminalDeviceId: self.squareTerminalDeviceId, hostUrl: self.hostUrl, isUseProductMock: self.isUseProductMock)
     }
     
     func save(config: Config) {
@@ -38,5 +40,6 @@ public struct ConfigAppStorage: ConfigRepository {
         self.isUseSquareTerminal = config.isUseSquareTerminal
         self.squareAccessToken = config.squareAccessToken
         self.squareTerminalDeviceId = config.squareTerminalDeviceId
+        self.isUseProductMock = config.isUseProductMock
     }
 }

--- a/LogoREGIUI/Sources/Features/OrderEntryFeature/ProductStackFeature/ProductStackFeature.swift
+++ b/LogoREGIUI/Sources/Features/OrderEntryFeature/ProductStackFeature/ProductStackFeature.swift
@@ -37,11 +37,23 @@ public struct ProductStackFeature {
             switch action {
             case .fetch:
                 return .run { send in
-                    await send(
-                        .fetched(
-                            Result { await GetCategoriesWithProduct().Execute() }
+                    let config = GetConfig().Execute()
+
+                    if config.isUseProductMock {
+                        // モックサービスを使用
+                        await send(
+                            .fetched(
+                                Result { await ProductQueryServiceMock().fetchProductCategoriesWithProducts() }
+                            )
                         )
-                    )
+                    } else {
+                        // APIサービスを使用
+                        await send(
+                            .fetched(
+                                Result { await GetCategoriesWithProduct().Execute() }
+                            )
+                        )
+                    }
                 }
             case let .fetched(.success(productCatalog)):
                 state.productCatalog = productCatalog
@@ -79,4 +91,3 @@ public struct ProductStackFeature {
         .ifLet(\.$destination, action: \.destination)
     }
 }
-

--- a/LogoREGIUI/Sources/Features/SettingFeature/SettingView.swift
+++ b/LogoREGIUI/Sources/Features/SettingFeature/SettingView.swift
@@ -86,6 +86,12 @@ struct SettingView: View {
                     Text("外部機器設定")
                 }
                 
+                Section {
+                    Toggle("商品モックを有効化", isOn: $store.isUseProductMock)
+                } header: {
+                    Text("開発設定")
+                }
+                
             }
         }
         .navigationTitle("設定")

--- a/LogoREGIUI/Sources/Features/SettingFeature/SettingsFeature.swift
+++ b/LogoREGIUI/Sources/Features/SettingFeature/SettingsFeature.swift
@@ -20,6 +20,8 @@ public struct SettingsFeature {
         var squareAccessToken: String = ""
         var squareTerminalDeviceId: String = ""
         
+        var isUseProductMock: Bool = false
+        
         var config: Config
         
         init() {
@@ -32,6 +34,7 @@ public struct SettingsFeature {
             self.isUseSquareTerminal = config.isUseSquareTerminal
             self.squareAccessToken = config.squareAccessToken
             self.squareTerminalDeviceId = config.squareTerminalDeviceId
+            self.isUseProductMock = config.isUseProductMock
         }
     }
     
@@ -60,7 +63,8 @@ public struct SettingsFeature {
                     state.isUseSquareTerminal != state.config.isUseSquareTerminal ||
                     state.squareAccessToken != state.config.squareAccessToken ||
                     state.squareTerminalDeviceId != state.config.squareTerminalDeviceId ||
-                    state.hostUrl != state.config.hostUrl
+                    state.hostUrl != state.config.hostUrl ||
+                    state.isUseProductMock != state.config.isUseProductMock
                 {
                     return .run { send in
                         await send(.saveConfig)
@@ -85,6 +89,7 @@ public struct SettingsFeature {
                     updatedConfig.squareAccessToken = state.squareAccessToken
                     updatedConfig.squareTerminalDeviceId = state.squareTerminalDeviceId
                     updatedConfig.hostUrl = state.hostUrl
+                    updatedConfig.isUseProductMock = state.isUseProductMock
                     SaveConfig().Execute(config: updatedConfig)
                 }
             case .loadConfig:
@@ -98,6 +103,7 @@ public struct SettingsFeature {
                 state.squareAccessToken = config.squareAccessToken
                 state.squareTerminalDeviceId = config.squareTerminalDeviceId
                 state.hostUrl = config.hostUrl
+                state.isUseProductMock = config.isUseProductMock
                 return .none
             }
         }

--- a/cafelogos-pos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cafelogos-pos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/star-micronics/StarXpand-SDK-iOS",
       "state" : {
-        "revision" : "aba5877b4514bff312ac9783fc46722c8734315f",
+        "revision" : "2fc49f245a0c8e2e460cb53383c908011e1e9d1f",
         "version" : "2.7.0"
       }
     },


### PR DESCRIPTION
# 概要
- サーバーサイドの開発環境を立てずとも、LogoREGIの注文入力画面のデバッグができるようにMockを流し込める設定を追加しました
  - 番号発券機能を作るにあたり実装
- Infra/MockにあるMockを直接呼び出しているので、ベストプラクティスではないと思いますが、テスト用のMockとデバッグ用のMockを共通化することを目論んでいるので、その時にリファクタしたいと思います


- コードはCline x Claude 3.7 sonnetに書かせましたが、DDDがまるでダメなのでプロンプトを改善する or 何か策を練る必要がありそうです

| 設定 | 注文入力|
| -- | -- |
|![image](https://github.com/user-attachments/assets/9dbacd1b-dc7b-417e-823c-36921f3d1b88)|![image](https://github.com/user-attachments/assets/eff55149-068c-460e-9b5e-27ff099d6030)

