### PR TITLE
パッケージバージョンのアップデート＆gRPC定義をlogosoneから取るようにする

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -18,17 +18,36 @@
 		35E810AA2C31AC0600E56F2D /* LogoREGIUI in Frameworks */ = {isa = PBXBuildFile; productRef = 35E810A92C31AC0600E56F2D /* LogoREGIUI */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		357B7CFA2D8418BD00BDA702 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3557C70C2A826A1200C72F17 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3557C7132A826A1200C72F17;
+			remoteInfo = "cafelogos-pos";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		3557C7142A826A1200C72F17 /* cafelogos-pos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "cafelogos-pos.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3557C7172A826A1200C72F17 /* cafelogos_posApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cafelogos_posApp.swift; sourceTree = "<group>"; };
 		3557C71B2A826A1300C72F17 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3557C71E2A826A1300C72F17 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		357B7CF62D8418BD00BDA702 /* cafelogos-posTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "cafelogos-posTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3586BDF62A8FC479009E346E /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		35B289922C31BD120014AD63 /* Signing.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		35B289932C31BD120014AD63 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		35B289942C31BD120014AD63 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		EBE8FF9B2AD1BCCC002011B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		357B7CF72D8418BD00BDA702 /* cafelogos-posTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "cafelogos-posTests";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		3557C7112A826A1200C72F17 /* Frameworks */ = {
@@ -37,6 +56,13 @@
 			files = (
 				35E810AA2C31AC0600E56F2D /* LogoREGIUI in Frameworks */,
 				35E810A82C31AC0300E56F2D /* LogoREGICore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		357B7CF32D8418BD00BDA702 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -51,6 +77,7 @@
 				35B289922C31BD120014AD63 /* Signing.xcconfig */,
 				3586BDF62A8FC479009E346E /* .gitignore */,
 				3557C7162A826A1200C72F17 /* App */,
+				357B7CF72D8418BD00BDA702 /* cafelogos-posTests */,
 				3557C7152A826A1200C72F17 /* Products */,
 				3564D86D2C319740000D8936 /* Frameworks */,
 			);
@@ -60,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				3557C7142A826A1200C72F17 /* cafelogos-pos.app */,
+				357B7CF62D8418BD00BDA702 /* cafelogos-posTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -114,6 +142,29 @@
 			productReference = 3557C7142A826A1200C72F17 /* cafelogos-pos.app */;
 			productType = "com.apple.product-type.application";
 		};
+		357B7CF52D8418BD00BDA702 /* cafelogos-posTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 357B7CFE2D8418BD00BDA702 /* Build configuration list for PBXNativeTarget "cafelogos-posTests" */;
+			buildPhases = (
+				357B7CF22D8418BD00BDA702 /* Sources */,
+				357B7CF32D8418BD00BDA702 /* Frameworks */,
+				357B7CF42D8418BD00BDA702 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				357B7CFB2D8418BD00BDA702 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				357B7CF72D8418BD00BDA702 /* cafelogos-posTests */,
+			);
+			name = "cafelogos-posTests";
+			packageProductDependencies = (
+			);
+			productName = "cafelogos-posTests";
+			productReference = 357B7CF62D8418BD00BDA702 /* cafelogos-posTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -121,11 +172,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1430;
+				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					3557C7132A826A1200C72F17 = {
 						CreatedOnToolsVersion = 14.3.1;
+					};
+					357B7CF52D8418BD00BDA702 = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 3557C7132A826A1200C72F17;
 					};
 				};
 			};
@@ -146,6 +201,7 @@
 			projectRoot = "";
 			targets = (
 				3557C7132A826A1200C72F17 /* cafelogos-pos */,
+				357B7CF52D8418BD00BDA702 /* cafelogos-posTests */,
 			);
 		};
 /* End PBXProject section */
@@ -164,6 +220,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		357B7CF42D8418BD00BDA702 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -175,7 +238,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		357B7CF22D8418BD00BDA702 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		357B7CFB2D8418BD00BDA702 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3557C7132A826A1200C72F17 /* cafelogos-pos */;
+			targetProxy = 357B7CFA2D8418BD00BDA702 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3557C7362A826A1300C72F17 /* Debug */ = {
@@ -374,6 +452,49 @@
 			};
 			name = Release;
 		};
+		357B7CFC2D8418BD00BDA702 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9P7M734N35;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "cloud.kagura.cafelogos-posTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cafelogos-pos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/cafelogos-pos";
+			};
+			name = Debug;
+		};
+		357B7CFD2D8418BD00BDA702 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9P7M734N35;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "cloud.kagura.cafelogos-posTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cafelogos-pos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/cafelogos-pos";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -391,6 +512,15 @@
 			buildConfigurations = (
 				3557C7392A826A1300C72F17 /* Debug */,
 				3557C73A2A826A1300C72F17 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		357B7CFE2D8418BD00BDA702 /* Build configuration list for PBXNativeTarget "cafelogos-posTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				357B7CFC2D8418BD00BDA702 /* Debug */,
+				357B7CFD2D8418BD00BDA702 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/App.xcodeproj/xcshareddata/xcschemes/cafelogos-pos.xcscheme
+++ b/App.xcodeproj/xcshareddata/xcschemes/cafelogos-pos.xcscheme
@@ -34,7 +34,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3557C7232A826A1300C72F17"
+               BlueprintIdentifier = "357B7CF52D8418BD00BDA702"
                BuildableName = "cafelogos-posTests.xctest"
                BlueprintName = "cafelogos-posTests"
                ReferencedContainer = "container:App.xcodeproj">

--- a/LogoREGICore/Package.swift
+++ b/LogoREGICore/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0"),
         .package(url: "https://github.com/yaslab/ULID.swift.git", from: "1.3.0"),
         .package(url: "https://github.com/realm/realm-swift.git", from: "10.52.0"),
-        .package(url: "https://github.com/KaguraGateway/cafelogos-grpc.git", branch: "main"),
-        .package(url: "https://github.com/connectrpc/connect-swift", from: "0.8.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.24.0"),
-        .package(url: "https://github.com/star-micronics/StarXpand-SDK-iOS", from: "2.6.0"),
+        .package(url: "https://github.com/KaguraGateway/logosone.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/connectrpc/connect-swift.git", from: "1.0.2"),
+        .package(url: "https://github.com/star-micronics/StarXpand-SDK-iOS", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0")
     ],
     targets: [
@@ -33,7 +33,7 @@ let package = Package(
                 .product(name: "Dependencies", package: "swift-dependencies"),
                 .product(name: "RealmSwift", package: "realm-swift"),
                 .product(name: "Connect", package: "connect-swift"),
-                .product(name: "cafelogos-grpc", package: "cafelogos-grpc")
+                .product(name: "cafelogos-grpc", package: "logosone")
             ]),
         .testTarget(
             name: "LogoREGICoreTests",

--- a/LogoREGIUI/Package.swift
+++ b/LogoREGIUI/Package.swift
@@ -14,13 +14,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-dependencies.git", from: "1.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.11.0"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.18.0"),
         .package(url: "https://github.com/yaslab/ULID.swift.git", from: "1.3.0"),
         .package(url: "https://github.com/realm/realm-swift.git", from: "10.52.0"),
-        .package(url: "https://github.com/KaguraGateway/cafelogos-grpc.git", branch: "main"),
-        .package(url: "https://github.com/connectrpc/connect-swift", from: "0.8.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.24.0"),
-        .package(url: "https://github.com/star-micronics/StarXpand-SDK-iOS", from: "2.6.0"),
+        .package(url: "https://github.com/KaguraGateway/logosone.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/connectrpc/connect-swift.git", from: "1.0.2"),
+        .package(url: "https://github.com/star-micronics/StarXpand-SDK-iOS", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0"),
         .package(url: "https://github.com/cybozu/WebUI.git", from: "3.0.0"),
         .package(path: "./LogoREGICore")
@@ -37,7 +37,7 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "RealmSwift", package: "realm-swift"),
                 .product(name: "Connect", package: "connect-swift"),
-                .product(name: "cafelogos-grpc", package: "cafelogos-grpc"),
+                .product(name: "cafelogos-grpc", package: "logosone"),
                 .product(name: "WebUI", package: "WebUI"),
                 .product(name: "LogoREGICore", package: "LogoREGICore")
             ]),

--- a/cafelogos-pos.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/cafelogos-pos.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/cafelogos-pos.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cafelogos-pos.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "cafelogos-grpc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/KaguraGateway/cafelogos-grpc.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "e732a295fb817d64dc90a7ac3fb12c565018ee80"
-      }
-    },
-    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
       }
     },
     {
@@ -23,8 +14,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/connectrpc/connect-swift",
       "state" : {
-        "revision" : "6d0f8edc1f7d68908c34fb6b25a49dce45aa55f9",
-        "version" : "0.14.0"
+        "revision" : "09e7dd47db03412b61a9d4bc20f17864b43fc778",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "logosone",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/KaguraGateway/logosone.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "c56ce1db15e4511d73c41bd39dfb52e4a0ab5ff0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/star-micronics/StarXpand-SDK-iOS",
       "state" : {
-        "revision" : "2fc49f245a0c8e2e460cb53383c908011e1e9d1f",
-        "version" : "2.7.0"
+        "revision" : "0d6faec2c759cedbbdb8ba5c8bfb76f4471b88d9",
+        "version" : "2.8.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "b871e5ed11a23e52c2896a92ce2c829982ff8619",
-        "version" : "1.4.2"
+        "revision" : "19b7263bacb9751f151ec0c93ec816fe1ef67c7b",
+        "version" : "1.6.1"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture",
       "state" : {
-        "revision" : "1f952d8c69ace5e53bb69a218e6ed00e03a4695c",
-        "version" : "1.11.2"
+        "revision" : "76c4411e02cc7768a3f27ca058bd2143c342e5b2",
+        "version" : "1.18.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies.git",
       "state" : {
-        "revision" : "00bc30ca03f98881329fab7f1bebef8eba472596",
-        "version" : "1.3.1"
+        "revision" : "ec2862d1364536fc22ec56a3094e7a034bbc7da8",
+        "version" : "1.8.1"
       }
     },
     {
@@ -145,12 +145,21 @@
       }
     },
     {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
+        "version" : "2.3.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e5a216ba89deba84356bad9d4c2eab99071c745b",
-        "version" : "2.67.0"
+        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
+        "version" : "2.81.0"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "8d8eb609929aee75336a0a3d2417280786265868",
-        "version" : "1.32.0"
+        "revision" : "170f4ca06b6a9c57b811293cebcb96e81b661310",
+        "version" : "1.35.0"
       }
     },
     {
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "2b09805797f21c380f7dc9bedaab3157c5508efb",
-        "version" : "2.27.0"
+        "revision" : "0cc3528ff48129d64ab9cab0b1cd621634edfc6b",
+        "version" : "2.29.3"
       }
     },
     {
@@ -185,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "d3ab98dc2887d1cc3bed676f6fa354da4cb22b3c",
-        "version" : "1.2.4"
+        "revision" : "671fa54b279fd73933b4a8b34782ebf6c8869145",
+        "version" : "1.5.1"
       }
     },
     {
@@ -194,14 +203,23 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
-        "version" : "1.26.0"
+        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
+        "version" : "1.29.0"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "2c840cf2ae0526ad6090e7796c4e13d9a2339f4a",
+        "version" : "2.3.3"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"
@@ -212,17 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
-        "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "swiftui-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
-      "state" : {
-        "revision" : "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
-        "version" : "1.5.0"
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
       }
     },
     {
@@ -248,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/cafelogos-posTests/cafelogos_posTests.swift
+++ b/cafelogos-posTests/cafelogos_posTests.swift
@@ -1,0 +1,17 @@
+//
+//  cafelogos_posTests.swift
+//  cafelogos-posTests
+//  
+//  Created by　KaguraGateway on 2025/03/14
+//  
+//
+
+import Testing
+
+struct cafelogos_posTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}


### PR DESCRIPTION
- パッケージバージョンアップ
  - Connect-Swift
  - TCA
  - StarXpand SDK
- gRPC定義を KaguraGateway/cafelogos-grpc から KaguraGateway/logosone に移行するのに追随