### PR TITLE
ホーム画面のUI変更

### DIFF
--- a/LogoREGIUI/Sources/Features/HomeFeature/HomeView.swift
+++ b/LogoREGIUI/Sources/Features/HomeFeature/HomeView.swift
@@ -31,15 +31,26 @@ struct HomeView: View {
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
                             bgColor: Color(.white),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height,
+                            height: geometry.size.height * (1/2),
                             icon: "cart",
                             state: AppFeature.Path.State.orderEntry(OrderEntryFeature.State())
+                        )
+                        HomeNavigationButton(
+                            title: "注文履歴",
+                            subTitle: "",
+                            description: "決済履歴を参照する",
+                            fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
+                            bgColor: Color(.white),
+                            width: geometry.size.width * (1/3),
+                            height: geometry.size.height * (1/2),
+                            icon: "list.bullet.clipboard",
+                            state: AppFeature.Path.State.paymentList(PaymentListFeature.State())
                         )
                     }
                     // 中央列
                     VStack(alignment: .leading, spacing: 15) {
                         HomeNavigationButton(
-                            title: "レジ入金",
+                            title: "入金",
                             subTitle: "",
                             description: "レジ内の釣り銭を設定",
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
@@ -50,7 +61,7 @@ struct HomeView: View {
                             state: AppFeature.Path.State.cashDrawerSetup(CashDrawerOperationsFeature.State())
                         )
                         HomeNavigationButton(
-                            title: "レジ点検",
+                            title: "点検",
                             subTitle: "",
                             description: "レジ内の釣り銭を差分を確認",
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
@@ -61,7 +72,7 @@ struct HomeView: View {
                             state: AppFeature.Path.State.cashDrawerInspection(CashDrawerOperationsFeature.State())
                         )
                         HomeNavigationButton(
-                            title: "レジ精算",
+                            title: "精算",
                             subTitle: "",
                             description: "レジ内の釣り銭を差分を確認・保存",
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
@@ -72,7 +83,7 @@ struct HomeView: View {
                             state: AppFeature.Path.State.cashDrawerClosing(CashDrawerOperationsFeature.State())
                         )
                         HomeNavigationButton(
-                            title: "レジ操作履歴",
+                            title: "操作履歴",
                             subTitle: "",
                             description: "レジ開け・精算の記録一覧を表示",
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
@@ -81,17 +92,6 @@ struct HomeView: View {
                             height: geometry.size.height * (1/4),
                             icon: "clock.arrow.circlepath",
                             state: AppFeature.Path.State.cashDrawerHistory(CashDrawerHistoryFeature.State())
-                        )
-                        HomeNavigationButton(
-                            title: "レジ決済履歴",
-                            subTitle: "",
-                            description: "レジ内の決済履歴を確認",
-                            fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
-                            bgColor: Color(.white),
-                            width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/4),
-                            icon: "list.bullet.clipboard",
-                            state: AppFeature.Path.State.paymentList(PaymentListFeature.State())
                         )
                     }
                     // 右列
@@ -103,7 +103,7 @@ struct HomeView: View {
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
                             bgColor: Color(.white),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/4),
+                            height: geometry.size.height * (1/2),
                             icon: "chart.bar",
                             state: AppFeature.Path.State.ordersList(OrdersListFeature.State())
                         )
@@ -114,7 +114,7 @@ struct HomeView: View {
                             fgColor: Color(Color(red: 0.176, green: 0.216, blue: 0.282)),
                             bgColor: Color(.white),
                             width: geometry.size.width * (1/3),
-                            height: geometry.size.height * (1/4),
+                            height: geometry.size.height * (1/2),
                             icon: "gearshape",
                             state: AppFeature.Path.State.settings(SettingsFeature.State())
                         )


### PR DESCRIPTION
ホーム画面のUI変更
---
- 将来的にキャンセル機能もここに実装したいため、わかりやすくするために「注文履歴」の位置・大きさを変更しました
- 中央列のそれぞれのタイトルから「レジ」という単語を削除しました
- 右列のボタンの大きさを`1/4`から`1/2`に変更しました